### PR TITLE
Update from qt5 to qt6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
-FROM ubuntu:16.04
+FROM ubuntu:22.04
 
-ENV QT_VERSION v5.9.1
-ENV QT_CREATOR_VERSION v4.3.1
+ENV QT_VERSION v6.3.2
+ENV QT_CREATOR_VERSION v8.0.1
 
 # Build prerequisites
 RUN apt-get -y update && apt-get -y install qtbase5-dev \
 	libxcb-xinerama0-dev \
 	build-essential \
-	python
+	python3 \
+	cmake
 
 # Other useful tools
 RUN apt-get -y update && apt-get -y install tmux \

--- a/build_qt.sh
+++ b/build_qt.sh
@@ -42,7 +42,7 @@ SCRIPT_DIR=`dirname $SCRIPT_PATH`
 [[ -z ${QT_VERSION+x} ]] && QT_VERSION="master"
 [[ -z ${QT_J_LEVEL+x} ]] && QT_J_LEVEL=$((`nproc`+1))
 [[ -z ${QT_GIT_URL+x} ]] && QT_GIT_URL="https://code.qt.io/qt/qt5.git"
-[[ -z ${QT_WORKING_DIR+x} ]] && QT_WORKING_DIR="qt5"
+[[ -z ${QT_WORKING_DIR+x} ]] && QT_WORKING_DIR="qt6"
 [[ -z ${QT_INIT_REPOSITORY_OPTS+x} ]] && QT_INIT_REPOSITORY_OPTS="--module-subset=default,-qtwebkit,-qtwebkit-examples,-qtwebengine"
 [[ -z ${QT_CONFIGURE_OPTS+x} ]] && QT_CONFIGURE_OPTS="-opensource -nomake examples -nomake tests -confirm-license"
 [[ -z ${QT_CREATOR_GIT_URL+x} ]] && QT_CREATOR_GIT_URL="https://code.qt.io/qt-creator/qt-creator.git"
@@ -81,7 +81,7 @@ git checkout $QT_CREATOR_VERSION
 git submodule update --init
 mkdir qt-creator-build
 cd qt-creator-build
-qmake -r ../qtcreator.pro
+qmake -r ../qtcreator.pri
 [ $? -ne 0 ] && >&2 echo "ERROR: QT creator qmake failed" && exit 1
 make -j $QT_J_LEVEL
 [ $? -ne 0 ] && >&2 echo "ERROR: QT creator make failed" && exit 1


### PR DESCRIPTION
Move to qt6 and update in order to work in ubuntu:22.04 :

apt-get install of the following packages:
- python3 (not python)
- cmake (added)

Change destination directory from qt5 -> qt6

qt v6.3.2
qt creator v8.0.1

now it's
qmake -r ../qtcreator.pri